### PR TITLE
SfTextBoxExt ペースト処理のハンドリング

### DIFF
--- a/dropdown/AutoComplete/AutoComplete.xaml.cs
+++ b/dropdown/AutoComplete/AutoComplete.xaml.cs
@@ -7,6 +7,7 @@
 #endregion
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Windows;
@@ -36,6 +37,13 @@ namespace syncfusion.dropdowndemos.wpf
         public AutoCompleteDemo(string themename) : base(themename)
         {
             InitializeComponent();
+
+            DataObject.AddPastingHandler(autoComplete, OnAutoCompletePasting);
+        }
+
+        private void OnAutoCompletePasting(object sender, DataObjectPastingEventArgs e)
+        {
+            Debug.WriteLine("AutoComplete: OnPastring");
         }
 
         protected override void Dispose(bool disposing)


### PR DESCRIPTION
https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.Input.SfTextBoxExt.html

SfTextBoxExt は標準テキストボックス(Windows.UI.Xaml.Controls.TextBox) を拡張したものですので、標準のイベント処理が利用されます。

https://docs.microsoft.com/ja-jp/dotnet/api/system.windows.dataobject.pasting?view=windowsdesktop-6.0
https://docs.microsoft.com/ja-jp/dotnet/api/system.windows.dataobject.addpastinghandler?view=windowsdesktop-6.0

Ctrl+V でもコンテキストメニューのペーストでも内部的にはクリップボードのデータからの貼り付けが発生します。
上記クラス機能でペースト時のハンドラを登録しておく事により、対象コントロールへのペースト発生時の処理をカスタマイズできます。